### PR TITLE
Support for shorter syntax for multiple functions

### DIFF
--- a/src/TraceFuns.jl
+++ b/src/TraceFuns.jl
@@ -108,7 +108,7 @@ macro trace(expr, funs...)
     expresc = esc(expr)
     if funs isa Tuple{Expr}
         # macro was called as @trace expr fun1,fun2
-        # funs is something like (:((fun1, fun2)),), ie. Expr(:tuple, [:fun1, :fun2])
+        # funs is something like (:((fun1, fun2)),), ie. (Expr(:tuple, [:fun1, :fun2]),)
         funs = funs[1].args
     end
     funsesc = esc.(funs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,21 +14,53 @@ fibo(n::Integer) = if n < 2 1 else fibo(n - 1) + fibo(n - 2) end
 end
 
 @testset "Trace output" begin
-    trace = @capture_out begin
-        @trace fibo(3) fibo
-    end
-    
-    expected = [
-        "0: fibo(3) -- Method fibo(n::Integer)",
-        "   1: fibo(2) -- Method fibo(n::Integer)",
-        "       2: fibo(1) -- Method fibo(n::Integer)",
-        "       2: fibo(1) -> 1",
-        "       2: fibo(0) -- Method fibo(n::Integer)",
-        "       2: fibo(0) -> 1",
-        "   1: fibo(2) -> 2",
-        "   1: fibo(1) -- Method fibo(n::Integer)",
-        "   1: fibo(1) -> 1",
-        "0: fibo(3) -> 3"]
+    _all_start_with(expected) = trace -> all(map(startswith, split(trace, "\n"), expected))
+    _all_start_with(expected, trace) = _all_start_with(expected)(trace)
 
-    @test all(map(startswith, split(trace, "\n"), expected))
+    let trace = @capture_out begin
+            @trace fibo(3) fibo
+        end
+
+        expected = [
+            "0: fibo(3) -- Method fibo(n::Integer)",
+            "   1: fibo(2) -- Method fibo(n::Integer)",
+            "       2: fibo(1) -- Method fibo(n::Integer)",
+            "       2: fibo(1) -> 1",
+            "       2: fibo(0) -- Method fibo(n::Integer)",
+            "       2: fibo(0) -> 1",
+            "   1: fibo(2) -> 2",
+            "   1: fibo(1) -- Method fibo(n::Integer)",
+            "   1: fibo(1) -> 1",
+            "0: fibo(3) -> 3"]
+
+        @test _all_start_with(expected, trace)
+    end
+
+    @testset "with multiple functions" begin
+        expected = [
+            "0: fibo(3) -- Method fibo(n::Integer)",
+            "   1: fibo(2) -- Method fibo(n::Integer)",
+            "       2: fibo(1) -- Method fibo(n::Integer)",
+            "       2: fibo(1) -> 1",
+            "       2: fibo(0) -- Method fibo(n::Integer)",
+            "       2: fibo(0) -> 1",
+            "       2: +(1, 1) -- Method +(x::T, y::T)",
+            "       2: +(1, 1) -> 2",
+            "   1: fibo(2) -> 2",
+            "   1: fibo(1) -- Method fibo(n::Integer)",
+            "   1: fibo(1) -> 1",
+            "   1: +(2, 1) -- Method +(x::T, y::T)",
+            "   1: +(2, 1) -> 3",
+            "0: fibo(3) -> 3"]
+        _check = _all_start_with(expected)
+
+        let trace = @capture_out @trace(fibo(3), fibo, Base.:+)
+            @test _check(trace)
+        end
+
+        let trace = @capture_out @trace fibo(3) fibo, Base.:+
+            @test _check(trace)
+        end
+    end
+
 end


### PR DESCRIPTION
I found myself wishing that I could call the macro as `@trace expr fun1, fun2` in addition to the usual but more annoying to type `@trace(expr, fun1, fun2)`, so here's a PR.