### PR TITLE
Make it work in absence of fun metadata

### DIFF
--- a/src/TraceFuns.jl
+++ b/src/TraceFuns.jl
@@ -24,13 +24,13 @@ match(meth, fun::Module) = meth.module == fun
 
 function Cassette.overdub(ctx::TraceCtx, fun::Function, args...)
     meth = which(fun, Base.typesof(args...))
-    needprint = any(match(meth, fun) for fun in ctx.metadata.funs)
+    needprint = length(ctx.metadata.funs) == 0 || any(match(meth, fun) for fun in ctx.metadata.funs)
     if needprint && ctx.metadata.indent ≥ 0
         methstr = "Method $meth of $fun"
         println(indent(ctx.metadata.indent, "$(callstr(fun, args)) -- $methstr"))
     end
     if Cassette.canrecurse(ctx, fun, args...)
-        newctx = Cassette.similarcontext(ctx, metadata = (funs = ctx.metadata.funs, indent = ctx.metadata.indent + 1))
+        newctx = Cassette.similarcontext(ctx, metadata=(funs=ctx.metadata.funs, indent=ctx.metadata.indent + 1))
         # Note: Work around potential Cassette bugs ...
         try
             res = Cassette.recurse(newctx, fun, args...)
@@ -144,7 +144,7 @@ julia> tracing(Base, fac) do
 See [`@trace`](@ref) for further details.
 """
 function tracing(thunk, funs...)
-    Cassette.overdub(TraceCtx(metadata = (funs = [funs...], indent = -1)), thunk)
+    Cassette.overdub(TraceCtx(metadata=(funs=[funs...], indent=-1)), thunk)
 end
 
 end # module


### PR DESCRIPTION
Something must have changed since this library was written since the fun metadata is empty. 

It does seem to work with a simple change, though, e.g. 

```
0: length(@NamedTuple{state::Int64, next_state::Int64, action::Trace{CircularVectorBuffer{Int64, Vector{Int64}}, SubArray{Int64, 0, CircularVectorBuffer{Int64, Vector{Int64}}, Tuple{Int64}, true}}, reward::Trace{CircularVectorBuffer{Float32, Vector{Float32}}, SubArray{Float32, 0, CircularVectorBuffer{Float32, Vector{Float32}}, Tuple{Int64}, true}}, terminal::Trace{CircularVectorBuffer{Bool, Vector{Bool}}, SubArray{Bool, 0, CircularVectorBuffer{Bool, Vector{Bool}}, Tuple{Int64}, true}}}[]) -- Method length(es::EpisodesBuffer) @ ReinforcementLearningTrajectories ~/Work/Julia/ReinforcementLearningTrajectories.jl/src/episodes.jl:74 of length

   1: length(@NamedTuple{state::Int64, next_state::Int64, action::Trace{CircularVectorBuffer{Int64, Vector{Int64}}, SubArray{Int64, 0, CircularVectorBuffer{Int64, Vector{Int64}}, Tuple{Int64}, true}}, reward::Trace{CircularVectorBuffer{Float32, Vector{Float32}}, SubArray{Float32, 0, CircularVectorBuffer{Float32, Vector{Float32}}, Tuple{Int64}, true}}, terminal::Trace{CircularVectorBuffer{Bool, Vector{Bool}}, SubArray{Bool, 0, CircularVectorBuffer{Bool, Vector{Bool}}, Tuple{Int64}, true}}}[]) -- Method length(t::AbstractArray) @ Base abstractarray.jl:315 of length

       2: size(@NamedTuple{state::Int64, next_state::Int64, action::Trace{CircularVectorBuffer{Int64, Vector{Int64}}, SubArray{Int64, 0, CircularVectorBuffer{Int64, Vector{Int64}}, Tuple{Int64}, true}}, reward::Trace{CircularVectorBuffer{Float32, Vector{Float32}}, SubArray{Float32, 0, CircularVectorBuffer{Float32, Vector{Float32}}, Tuple{Int64}, true}}, terminal::Trace{CircularVectorBuffer{Bool, Vector{Bool}}, SubArray{Bool, 0, CircularVectorBuffer{Bool, Vector{Bool}}, Tuple{Int64}, true}}}[]) -- Method size(t::Traces) @ ReinforcementLearningTrajectories ~/Work/Julia/ReinforcementLearningTrajectories.jl/src/traces.jl:247 of size
           3: mapreduce(length, min, (@NamedTuple{state::Int64, next_state::Int64}[], Int64[], Float32[], Bool[])) -- Method mapreduce(f, op, itr; kw...) @ Base reduce.jl:307 of mapreduce
               4: apply_type(Tuple) -- Method apply_type(...) @ Core none:0 of apply_type
               4: apply_type(Tuple) -> Tuple{}
               4: apply_type(NamedTuple, (), Tuple{}) -- Method apply_type(...) @ Core none:0 of apply_type
...
```